### PR TITLE
Document title and table colors for org-mode.

### DIFF
--- a/jbeans-theme.el
+++ b/jbeans-theme.el
@@ -308,14 +308,17 @@
 ;;;;; NeoTree
        `(neo-dir-link-face                   ((,class (:foreground ,jbeans-blue-0))))
        `(neo-file-link-face                  ((,class (:foreground ,jbeans-fg))))
+;;;;; Org
        `(org-checkbox                        ((,class (:foreground ,jbeans-green-8))))
        `(org-date                            ((,class (:foreground ,jbeans-blue-0))))
+       `(org-document-title                  ((,class (:foreground ,jbeans-red-12))))
        `(org-done                            ((,class (:foreground ,jbeans-green-8))))
        `(org-level-1                         ((,class (:foreground ,jbeans-red-2))))
        `(org-level-2                         ((,class (:foreground ,jbeans-red-1))))
        `(org-level-3                         ((,class (:foreground ,jbeans-red-1))))
        `(org-link                            ((,class (:foreground ,jbeans-blue-1))))
        `(org-special-keyword                 ((,class (:foreground ,jbeans-blue-0))))
+       `(org-table                           ((,class (:foreground ,jbeans-orange-0))))
        `(org-todo                            ((,class (:foreground ,jbeans-yellow-4))))
 ;;;;; Region
        `(region                              ((,class (:background ,jbeans-grey-4))))


### PR DESCRIPTION
Added colors for org-mode's document title and table. If you'd rather have other colors then please reject this PR.
